### PR TITLE
Fix System Tests for Product Bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,3 +58,8 @@ jobs:
     - uses: workarea-commerce/ci/test@v1
       with:
         command: bin/rails app:workarea:test:plugins
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: screenshots
+        path: test/dummy/tmp/screenshots/

--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,5 @@ gemspec
 # gem 'byebug', group: [:development, :test]
 
 gem 'workarea'
+gem 'workarea-product_bundles',
+  github: 'workarea-commerce/workarea-product-bundles'

--- a/app/assets/stylesheets/workarea/storefront/components/_product_details.scss
+++ b/app/assets/stylesheets/workarea/storefront/components/_product_details.scss
@@ -2,6 +2,11 @@
     #PRODUCT-DETAILS
 \*------------------------------------*/
 
+$product-details-primary-image-max-width:  472px !default;
+$product-details-primary-image-ratio:      $product-image-ratio !default;
+
+$product-details-alt-image-selected-outline-color:  $highlight-color !default;
+
 $product-details-info-max-width: 480px !default;
 $product-details-id-color: $product-id-color !default;
 
@@ -80,3 +85,34 @@ $product-details-add-to-cart-margin-medium: ($spacing-unit * 7) !default;
                 display: block;
             }
         }
+
+        /**
+         * 1. provides positioning context for loading indicator
+         */
+        .product-details__primary-image {
+            position: relative; /* [1] */
+            max-width: $product-details-primary-image-max-width;
+        }
+
+            .product-details__primary-image-link {
+                display: block;
+                padding: 0 0 ((1 / $product-details-primary-image-ratio) * 100%);
+                height: 0;
+                vertical-align: top;
+            }
+
+                .product-details__primary-image-link-image {}
+
+
+        .product-details__alt-images {}
+
+            .product-details__alt-image {}
+
+                .product-details__alt-image-link {
+                    display: inline-block;
+                }
+
+                .product-details__alt-image-link--selected {
+                    cursor: default;
+                    outline: 1px solid $product-details-alt-image-selected-outline-color;
+                }

--- a/test/system/workarea/storefront/categories_with_packages_system_test.decorator
+++ b/test/system/workarea/storefront/categories_with_packages_system_test.decorator
@@ -1,0 +1,74 @@
+module Workarea
+  module Storefront
+    if Plugin.installed? :product_bundles
+      decorate CategoriesWithPackagesSystemTest, with: :nvy do
+        def test_basic_category_setup
+          category = create_category
+          categorize_products(category)
+
+          visit storefront.category_path(category)
+
+          assert_text('Integration Product 1')
+          assert_text('Integration Product 2')
+          assert_text('Integration Package Product 1')
+          assert_text('$10.00')
+          assert_text('$5.00')
+          assert_text("Medium\n3")
+          assert_text("Small\n2")
+        end
+
+        def test_filtering_products
+          category = create_category
+          categorize_products(category)
+
+          visit storefront.category_path(category)
+
+          Capybara.match = :first
+          click_link '$10.00 - $19.99'
+
+          assert(page.has_content?('Integration Product 1'))
+          assert(page.has_no_content?('Integration Product 2'))
+          assert(page.has_content?('Integration Package Product 1'))
+
+          click_link '$10.00 - $19.99 (remove)'
+
+          assert(page.has_content?('Integration Product 1'))
+          assert(page.has_content?('Integration Product 2'))
+          assert(page.has_content?('Integration Package Product 1'))
+
+          click_link 'Extra Large'
+
+          assert(page.has_content?('Integration Package Product 1'))
+          assert(page.has_no_content?('Integration Product 1'))
+          assert(page.has_no_content?('Integration Product 2'))
+
+          click_link 'Extra Large (remove)'
+
+          assert(page.has_content?('Integration Product 1'))
+          assert(page.has_content?('Integration Product 2'))
+          assert(page.has_content?('Integration Package Product 1'))
+        end
+
+        def test_product_filtering_and_sorting
+          category = create_category
+          categorize_products(category)
+
+          visit storefront.category_path(category)
+
+          Capybara.match = :first
+          click_link '$10.00 - $19.99'
+
+          assert(page.has_content?('Integration Product 1'))
+          assert(page.has_no_content?('Integration Product 2'))
+          assert(page.has_content?('Integration Package Product 1'))
+
+          select('Price, Low to High', from: 'sort_top')
+
+          assert(page.has_content?('Integration Product 1'))
+          assert(page.has_no_content?('Integration Product 2'))
+          assert(page.has_content?('Integration Package Product 1'))
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
When installing the NVY theme with the `workarea-product_bundles` plugin, the system tests for bundles fail because the UI in NVY is slightly different.